### PR TITLE
DATAGO-39143: Disable the RTO test on Macs since it causes issues for some M1 chips

### DIFF
--- a/service/application/src/test/java/com/solace/maas/ep/runtime/agent/messagingServices/RtoMessagingServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/runtime/agent/messagingServices/RtoMessagingServiceTests.java
@@ -8,13 +8,13 @@ import com.solacesystems.solclientj.core.event.MessageCallback;
 import com.solacesystems.solclientj.core.event.SessionEventCallback;
 import com.solacesystems.solclientj.core.handle.SessionHandle;
 import lombok.SneakyThrows;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.DisabledIf;
 
 import java.util.ArrayList;
 
@@ -35,7 +35,10 @@ public class RtoMessagingServiceTests {
     @Mock
     SessionEventCallback sessionEventCallback;
 
-    @Ignore
+    @DisabledIf(
+            expression = "#{systemProperties['os.name'].toLowerCase().contains('mac')}",
+            reason = "Disabled on Mac OS"
+    )
     @SneakyThrows
     @Test
     public void RtoMessagingService_Create_Context_And_Session_Then_Connect() {


### PR DESCRIPTION
Disable the RTO test on Macs since it causes issues for some M1 chips