### PR TITLE
Chore: Sonar Scan should trigger into the `main` branch not `develop`

### DIFF
--- a/.github/workflows/sonar-scan.yaml
+++ b/.github/workflows/sonar-scan.yaml
@@ -2,7 +2,7 @@ name: SonarQube
 on:
   push:
     branches:
-      develop
+      main
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
- Change Sonar Scan workflow to run on the default branch `main` instead of `develop`