### PR TITLE
The Event Management Agent should be case in-sensitive

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/runtime/agent/scanManager/ScanManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/runtime/agent/scanManager/ScanManager.java
@@ -37,9 +37,10 @@ public class ScanManager {
         MessagingServiceEntity messagingServiceEntity = retrieveMessagingServiceEntity(messagingServiceId);
 
         MessagingServiceRouteDelegate scanDelegate =
-                PluginLoader.findPlugin(messagingServiceEntity.getMessagingServiceType());
+                PluginLoader.findPlugin(messagingServiceEntity.getMessagingServiceType().toUpperCase());
 
-        Objects.requireNonNull(scanDelegate, "Messaging Service Plugin not found!");
+        Objects.requireNonNull(scanDelegate, "Unable to find messaging service plugin for plugin type "
+                +messagingServiceEntity.getMessagingServiceType()+". Valid types are \"SOLACE\", \"KAFKA\".");
 
         List<String> scanDestinations = scanRequestBO.getDestinations();
         List<RouteBundle> destinations = scanDestinations.stream()

--- a/service/application/src/main/java/com/solace/maas/ep/runtime/agent/scanManager/ScanManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/runtime/agent/scanManager/ScanManager.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -21,7 +22,7 @@ public class ScanManager {
 
     private final MessagingServiceDelegateServiceImpl messagingServiceDelegateService;
     private final ScanService scanService;
-
+    private final String[] VALID_MESSAGING_SERVICE_TYPES = {"SOLACE", "KAFKA"};
 
     @Autowired
     public ScanManager(MessagingServiceDelegateServiceImpl messagingServiceDelegateService,
@@ -39,8 +40,10 @@ public class ScanManager {
         MessagingServiceRouteDelegate scanDelegate =
                 PluginLoader.findPlugin(messagingServiceEntity.getMessagingServiceType().toUpperCase());
 
-        Objects.requireNonNull(scanDelegate, "Unable to find messaging service plugin for plugin type "
-                +messagingServiceEntity.getMessagingServiceType()+". Valid types are \"SOLACE\", \"KAFKA\".");
+        Objects.requireNonNull(scanDelegate,
+                String.format("Unable to find messaging service plugin for plugin type %s. Valid types are %s.",
+                        messagingServiceEntity.getMessagingServiceType(),
+                        String.join(", ", VALID_MESSAGING_SERVICE_TYPES)));
 
         List<String> scanDestinations = scanRequestBO.getDestinations();
         List<RouteBundle> destinations = scanDestinations.stream()

--- a/service/application/src/main/java/com/solace/maas/ep/runtime/agent/scanManager/ScanManager.java
+++ b/service/application/src/main/java/com/solace/maas/ep/runtime/agent/scanManager/ScanManager.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 @Service

--- a/service/application/src/main/java/com/solace/maas/ep/runtime/agent/service/MessagingServiceDelegateServiceImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/runtime/agent/service/MessagingServiceDelegateServiceImpl.java
@@ -120,7 +120,7 @@ public class MessagingServiceDelegateServiceImpl implements MessagingServiceDele
                 .build();
 
         // Get the Messaging Service type.
-        String type = messagingServiceEntity.getMessagingServiceType();
+        String type = messagingServiceEntity.getMessagingServiceType().toUpperCase();
 
         if (messagingServiceClients.containsKey(messagingServiceId)) {
             return (T) messagingServiceClients.get(messagingServiceId);


### PR DESCRIPTION
When the configuration file is generated from the runtime agent we specify the messaging service type as solace or kafka "lowercase". The runtime should accept the types as case in sensitive